### PR TITLE
docs(README.md): add dependences

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 资源版权归kugou所有。
 
+## Run
+
+install dependences
+
+```shell
+sudo apt-get install  libqt5multimedia5-plugins
+```
+
+if no `libqt5multimedia5-plugins` installed, there is a error.
+
+```shell
+defaultServiceProvider::requestService(): no service found for - "org.qt-project.qt.mediaplayer"
+```
+
 ## License
 
 ![](http://www.gnu.org/graphics/gplv3-127x51.png)


### PR DESCRIPTION
if no `libqt5multimedia5-plugins` installed, there is a error.
```shell
    defaultServiceProvider::requestService(): no service found for - "org.qt-project.qt.mediaplayer"
```
